### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ module.exports = {
         test: /fileInWhichJQueryIsUndefined\.js$/,
         loader: 'string-replace-loader',
         options: {
-          search: /\$/i,
+          search: /\\$/i,
           replace: 'window.jQuery'
         }
       }
@@ -81,7 +81,7 @@ module.exports = {
         test: /fileInWhichJQueryIsUndefined\.js$/,
         loader: 'string-replace-loader',
         options: {
-          search: '\$',
+          search: '\\$',
           replace: 'window.jQuery',
           flags: 'i'
         }


### PR DESCRIPTION
replace `\` with `\\` as it gave me a hard time figuring what's wrong with the replacer in such string `$APPID$` and using `\$` would just return plain `$` and then parsed as the end of matcher, so you should use `\\$` so it passes `\$` to the regex, and then it works fines.